### PR TITLE
Fixes app naming

### DIFF
--- a/terraform/importables/onelogin_apps.go
+++ b/terraform/importables/onelogin_apps.go
@@ -49,7 +49,6 @@ func assembleResourceDefinitions(allApps []apps.App) []ResourceDefinition {
 		resourceDefinition := ResourceDefinition{
 			Provider: "onelogin",
 			ImportID: fmt.Sprintf("%d", *app.ID),
-			Name:     utils.ToSnakeCase(utils.ReplaceSpecialChar(*app.Name, "")),
 		}
 		switch *app.AuthMethod {
 		case 8:
@@ -59,6 +58,7 @@ func assembleResourceDefinitions(allApps []apps.App) []ResourceDefinition {
 		default:
 			resourceDefinition.Type = "onelogin_apps"
 		}
+		resourceDefinition.Name = fmt.Sprintf("%s_%s-%d", utils.ToSnakeCase(resourceDefinition.Type), utils.ToSnakeCase(utils.ReplaceSpecialChar(*app.Name, "")), *app.ID)
 		resourceDefinitions[i] = resourceDefinition
 	}
 	return resourceDefinitions

--- a/terraform/importables/onelogin_apps_test.go
+++ b/terraform/importables/onelogin_apps_test.go
@@ -19,9 +19,9 @@ func TestAssembleResourceDefinitions(t *testing.T) {
 				apps.App{Name: oltypes.String("test3"), AuthMethod: oltypes.Int32(1), ID: oltypes.Int32(3)},
 			},
 			ExpectedOut: []ResourceDefinition{
-				ResourceDefinition{Provider: "onelogin", Type: "onelogin_oidc_apps", ImportID: "1", Name: "test1"},
-				ResourceDefinition{Provider: "onelogin", Type: "onelogin_saml_apps", ImportID: "2", Name: "test2"},
-				ResourceDefinition{Provider: "onelogin", Type: "onelogin_apps", ImportID: "3", Name: "test3"},
+				ResourceDefinition{Provider: "onelogin", Type: "onelogin_oidc_apps", ImportID: "1", Name: "onelogin_oidc_apps_test1-1"},
+				ResourceDefinition{Provider: "onelogin", Type: "onelogin_saml_apps", ImportID: "2", Name: "onelogin_saml_apps_test2-2"},
+				ResourceDefinition{Provider: "onelogin", Type: "onelogin_apps", ImportID: "3", Name: "onelogin_apps_test3-3"},
 			},
 		},
 	}
@@ -54,14 +54,14 @@ func TestImportAppFromRemote(t *testing.T) {
 		"It pulls all apps of a certain type": {
 			Importable: OneloginAppsImportable{AppType: "onelogin_saml_apps", Service: MockAppsService{}},
 			Expected: []ResourceDefinition{
-				ResourceDefinition{Provider: "onelogin", Name: "test2", ImportID: "2", Type: "onelogin_saml_apps"},
+				ResourceDefinition{Provider: "onelogin", Name: "onelogin_saml_apps_test2-2", ImportID: "2", Type: "onelogin_saml_apps"},
 			},
 		},
 		"It gets one app": {
 			SearchID:   oltypes.String("2"),
 			Importable: OneloginAppsImportable{AppType: "onelogin_saml_apps", Service: MockAppsService{}},
 			Expected: []ResourceDefinition{
-				ResourceDefinition{Provider: "onelogin", Name: "test2", ImportID: "2", Type: "onelogin_saml_apps"},
+				ResourceDefinition{Provider: "onelogin", Name: "onelogin_saml_apps_test2-2", ImportID: "2", Type: "onelogin_saml_apps"},
 			},
 		},
 	}


### PR DESCRIPTION
Changes the naming of the app resource to the following format:

`resource_type_app_name-app_id`

This is to avoid duplicate app names and to fix an error when importing apps starting with a number.

Also see https://github.com/onelogin/onelogin/issues/20, bug introduced in https://github.com/onelogin/onelogin/commit/225221b3cd86e05d1fd35b5a318fbedd4cdf5bc7.